### PR TITLE
Show robot emoji with new style

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -65,6 +65,11 @@ h1 {
     text-shadow: 0 0 5px #00f7ff66;
     margin-bottom: 2rem;
 }
+h1 .emoji {
+    background: none;
+    -webkit-background-clip: border-box;
+    -webkit-text-fill-color: initial;
+}
 
 label {
     font-size: 0.9rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
         <a href="?lang=en" class="lang-option{% if lang == 'en' %} active{% endif %}">🇺🇸 EN</a>
         <a href="?lang=zh" class="lang-option{% if lang == 'zh' %} active{% endif %}">🇨🇳 中文</a>
     </div>
-    <h1>{{ t['title'] }}</h1>
+    <h1>{{ t['title'].replace('🤖', '<span class="emoji">🤖</span>')|safe }}</h1>
 
     {% with messages = get_flashed_messages() %}
     {% if messages %}


### PR DESCRIPTION
## Summary
- restore robot emoji in titles
- add a span wrapper for the emoji in the header so gradient styles don't hide it
- tweak CSS so the emoji uses normal colors

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841460d3764832db3a42a0836887046